### PR TITLE
Added fix for workflows error

### DIFF
--- a/.github/workflows/deploy-to-pages-and-release.yml
+++ b/.github/workflows/deploy-to-pages-and-release.yml
@@ -12,6 +12,8 @@ jobs:
   publish-release:
     needs: build-and-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Added permissions fix for the publish-release job of the workflow. This should allow releases to be created and published, which was denied before by relying only on the GITHUB_TOKEN permissions.